### PR TITLE
Using configuration for `xla_device`

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -102,6 +102,9 @@ class PretrainedConfig(object):
         # task specific arguments
         self.task_specific_params = kwargs.pop("task_specific_params", None)
 
+        # TPU arguments
+        self.xla_device = kwargs.pop("xla_device", None)
+
         # Additional attributes without default values
         for key, value in kwargs.items():
             try:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -320,13 +320,12 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
 
         self.base_model._prune_heads(heads_to_prune)
 
-    def save_pretrained(self, save_directory, xla_device=False):
+    def save_pretrained(self, save_directory):
         """ Save a model and its configuration file to a directory, so that it
             can be re-loaded using the `:func:`~transformers.PreTrainedModel.from_pretrained`` class method.
 
             Arguments:
                 save_directory: directory to which to save.
-                xla_device: True if saving after training on TPU/XLA.
         """
         assert os.path.isdir(
             save_directory
@@ -341,7 +340,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
         # If we save using the predefined names, we can load using `from_pretrained`
         output_model_file = os.path.join(save_directory, WEIGHTS_NAME)
 
-        if xla_device:
+        if hasattr(self.config, "xla_device") and self.config.xla_device:
             import torch_xla.core.xla_model as xm
 
             if xm.is_master_ordinal():
@@ -435,7 +434,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
         proxies = kwargs.pop("proxies", None)
         output_loading_info = kwargs.pop("output_loading_info", False)
         local_files_only = kwargs.pop("local_files_only", False)
-        xla_device = kwargs.pop("xla_device", False)
 
         # Load config if we don't provide a configuration
         if not isinstance(config, PretrainedConfig):
@@ -640,7 +638,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin):
             }
             return model, loading_info
 
-        if xla_device:
+        if hasattr(config, "xla_device") and config.xla_device:
             import torch_xla.core.xla_model as xm
 
             model = xm.send_cpu_data_to_device(model, xm.xla_device())


### PR DESCRIPTION
Using the model configuration file is usually preferred to adding new arguments on methods such as `save_pretrained`/`from_pretrained`.

There is no addition to the `examples/run_glue_tpu.py` file as the `xla_device=True` flag was already specified to the configuration file. That's all that's needed now :slightly_smiling_face: 

Here's a brief explanation of how that would work:

```py
from transformers import BertConfig, BertModel

config = BertConfig.from_pretrained("bert-base-cased", xla_config=True)  # config.xla_device == True
config.save_pretrained("directory")
config = BertConfig.from_pretrained("directory")  # config.xla_device == True
config = BertConfig.from_pretrained("directory", xla_device=False)  # config.xla_device == False
```

Here's how you would save/load using an XLA device:

```py
from transformers import BertConfig, BertModel

# With that configuration flag the model is loaded automatically on TPU
config = BertConfig.from_pretrained("bert-base-cased", xla_config=True)
model = BertModel.from_pretrained("bert-base-cased", config=config)

# Saved automatically on TPU
model.save_pretrained("directory")

# If we want to load without TPU
config = BertConfig.from_pretrained("directory", xla_config=False)
model = BertModel.from_pretrained("directory", config=config)
```

It can be done simply as well without explicitly using the config:

```py
from transformers import BertModel

model = BertModel.from_pretrained("bert-base-cased", xla_device=True)
model.config.xla_device  # True
```